### PR TITLE
Upgrade to CMake 3 and standard modules

### DIFF
--- a/project_template/CMakeLists.txt
+++ b/project_template/CMakeLists.txt
@@ -1,13 +1,47 @@
-cmake_minimum_required(VERSION 2.8)
+# - Define the minimum CMake version
+# HSF recommends 3.3 to support C/C++ compile features for C/C++11 across all
+# platforms
+cmake_minimum_required(VERSION 3.3)
+# - Call project() to setup system
+# From CMake 3, we can set the project version easily in one go
+project(HSFTEMPLATE VERSION 0.1.0)
 
-project(HSFTEMPLATE)
-set( HSFTEMPLATE_VERSION_MAJOR 0 )
-set( HSFTEMPLATE_VERSION_MINOR 1 )
-set( HSFTEMPLATE_VERSION_PATCH 0 )
-set( HSFTEMPLATE_VERSION "${HSFTEMPLATE_VERSION_MAJOR}.${HSFTEMPLATE_VERSION_MINOR}" )
+#--- Define basic build settings -----------------------------------------------
+# - Use GNU-style hierarchy for installing build products
+include(GNUInstallDirs)
 
-set(CMAKE_BUILD_TYPE Release)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+# - Define a default build type when using a single-mode tool like make/ninja
+# If you're using a build tool that supports multiple modes (Visual Studio,
+# Xcode), this setting has no effect.
+# HSF recommend RelWithDebInfo (optimized with debugging symbols) as this is
+# generally the mode used by system packaging (rpm, deb, spack, macports).
+# However, it can be overriden by passing ``-DCMAKE_BUILD_TYPE=<type>`` when
+# invoking CMake
+if(NOT CMAKE_CONFIGURATION_TYPES)
+  if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE RelWithDebInfo
+      CACHE STRING "Choose the type of build, options are: None Release MinSizeRel Debug RelWithDebInfo"
+      FORCE
+      )
+  else()
+    set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}"
+      CACHE STRING "Choose the type of build, options are: None Release MinSizeRel Debug RelWithDebInfo"
+      FORCE
+      )
+  endif()
+endif()
+
+# - Define the C++ Standard to use (Simplest Possible)
+# This will add any compiler flags needed to compile against the required standard
+# without any vendor extensions
+# NOTE: It *does not* guarantee that the compiler in use supports the complete
+# standard. Nor does it inform clients of the project what standard was used.
+# Both of these issues can be resolved using CMake's compile features, see
+#
+# - https://cmake.org/cmake/help/v3.3/manual/cmake-compile-features.7.html
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 #--- Declare options -----------------------------------------------------------
 option(HSFTEMPLATE_documentation "Whether or not to create doxygen doc target.")
@@ -27,7 +61,7 @@ endif()
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/HSFTEMPLATEVersion.h
                ${CMAKE_CURRENT_BINARY_DIR}/HSFTEMPLATEVersion.h )
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/HSFTEMPLATEVersion.h
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/include/HSFTEMPLATE )
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/HSFTEMPLATE )
 
 #--- add CMake infrastructure --------------------------------------------------
 include(cmake/HSFTEMPLATECreateConfig.cmake)
@@ -35,7 +69,7 @@ include(cmake/HSFTEMPLATECreateConfig.cmake)
 #--- add license files ---------------------------------------------------------
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE
               ${CMAKE_CURRENT_SOURCE_DIR}/NOTICE
-        DESTINATION ${CMAKE_INSTALL_PREFIX})
+              DESTINATION ${CMAKE_INSTALL_DOCDIR})
 
 #--- project specific subdirectories -------------------------------------------
 add_subdirectory(HSFSUBPACKAGE)

--- a/project_template/cmake/HSFTEMPLATEConfig.cmake.in
+++ b/project_template/cmake/HSFTEMPLATEConfig.cmake.in
@@ -1,15 +1,17 @@
 # - Config file for the HSFTEMPLATE package
-# It defines the following variables
-#  HSFTEMPLATE_INCLUDE_DIRS - include directories
-#  HSFTEMPLATE_LIBRARIES    - libraries to link against
-#  HSFTEMPLATE_LIBRARY_DIR  - HSFTEMPLATE library dir
-#  HSFTEMPLATE_BINARY_DIR   - binary directory
 
-# Compute paths
-get_filename_component(HSFTEMPLATE_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+# - Define exported version
+set(HSFTEMPLATE_VERSION "@PROJECT_VERSION@")
 
-get_filename_component(HSFTEMPLATE_INCLUDE_DIRS "${HSFTEMPLATE_CMAKE_DIR}/../include" ABSOLUTE)
-get_filename_component(HSFTEMPLATE_BINARY_DIR "${HSFTEMPLATE_CMAKE_DIR}/../bin" ABSOLUTE)
-get_filename_component(HSFTEMPLATE_LIBRARY_DIR "${HSFTEMPLATE_CMAKE_DIR}/../lib" ABSOLUTE)
+# - Init CMakePackageConfigHelpers
+@PACKAGE_INIT@
 
-ADD_LIBRARY(examplelibrary SHARED IMPORTED)
+# - Create relocatable paths to headers.
+# NOTE: Do not strictly need paths as all usage requirements are encoded in
+# the imported targets created later.
+set_and_check(HSFTEMPLATE_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+
+# - Include the targets file to create the imported targets that a client can
+# link to (libraries) or execute (programs)
+include("${CMAKE_CURRENT_LIST_DIR}/HSFTEMPLATETargets.cmake")
+

--- a/project_template/cmake/HSFTEMPLATECreateConfig.cmake
+++ b/project_template/cmake/HSFTEMPLATECreateConfig.cmake
@@ -1,9 +1,30 @@
+# - Use CMake's module to help generating relocatable config files
 include(CMakePackageConfigHelpers)
-configure_file(cmake/HSFTEMPLATEConfig.cmake.in "${PROJECT_BINARY_DIR}/HSFTEMPLATEConfig.cmake" @ONLY)
-write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/HSFTEMPLATEConfigVersion.cmake
-                                 VERSION ${HSFTEMPLATE_VERSION}
-                                 COMPATIBILITY SameMajorVersion )
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/HSFTEMPLATEConfig.cmake
-              ${CMAKE_CURRENT_BINARY_DIR}/HSFTEMPLATEConfigVersion.cmake
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/cmake )
+# - Versioning
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/HSFTEMPLATEConfigVersion.cmake
+  VERSION ${HSFTEMPLATE_VERSION}
+  COMPATIBILITY SameMajorVersion)
+
+# - Install time config and target files
+configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/HSFTEMPLATEConfig.cmake.in
+  "${PROJECT_BINARY_DIR}/HSFTEMPLATEConfig.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/HSFTEMPLATE"
+  PATH_VARS
+    CMAKE_INSTALL_BINDIR
+    CMAKE_INSTALL_INCLUDEDIR
+    CMAKE_INSTALL_LIBDIR
+  )
+
+# - install and export
+install(FILES
+  "${PROJECT_BINARY_DIR}/HSFTEMPLATEConfigVersion.cmake"
+  "${PROJECT_BINARY_DIR}/HSFTEMPLATEConfig.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/HSFTEMPLATE"
+  )
+install(EXPORT HSFTEMPLATETargets
+  NAMESPACE HSFTEMPLATE::
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/HSFTEMPLATE"
+  )
+

--- a/project_template/cmake/HSFTEMPLATEDoxygen.cmake
+++ b/project_template/cmake/HSFTEMPLATEDoxygen.cmake
@@ -7,5 +7,7 @@ if(DOXYGEN_FOUND)
                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                     COMMENT "Generating API documentation with Doxygen" VERBATIM)
 
-  install( DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doxygen DESTINATION doxygen OPTIONAL)
-endif(DOXYGEN_FOUND)
+  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doxygen
+    DESTINATION ${CMAKE_INSTALL_DOCDIR}/doxygen
+    OPTIONAL)
+endif()

--- a/project_template/package/CMakeLists.txt
+++ b/project_template/package/CMakeLists.txt
@@ -1,21 +1,31 @@
-## add include directory
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
-
 ## select all source files
 file(GLOB sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 
 ## create a library target
 add_library(examplelibrary SHARED ${sources})
 
+# - Define its header interface when building and when installed
+# (i.e. used by a third party)
+target_include_directories(examplelibrary
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    )
+
 ## if needed, link against "someexternal"
 ## which has been included with find_package(someexternal)
 #target_link_libraries(examplelibrary ${someexternal_LIBRARIES})
 
-## install the example library into lib/
-install(TARGETS examplelibrary DESTINATION lib)
+# - Install the example library into the install time library directory
+# The EXPORT name is used so that we can "export" the target for
+# use by client projects
+install(TARGETS examplelibrary
+  EXPORT HSFTEMPLATETargets
+  DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 ## install the headers
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/HSFTEMPLATE DESTINATION include)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/HSFTEMPLATE
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 ## handling of test executables
 add_subdirectory(tests)

--- a/project_template/package/tests/CMakeLists.txt
+++ b/project_template/package/tests/CMakeLists.txt
@@ -1,4 +1,7 @@
-find_package(GTest)
+# Find gtest or fail
+# NOTE: GTest recommends that it be vendored into the project rather
+# than used from the system!
+find_package(GTest REQUIRED)
 
 ## handling of test executables
 ## here a generic example for creating one executable per .cpp is shown
@@ -8,6 +11,5 @@ foreach( sourcefile ${tests} )
   string( REPLACE ".cpp" "" name ${sourcefile} )
   add_executable( ${name} ${sourcefile} )
   target_link_libraries( ${name} examplelibrary  ${GTEST_LIBRARIES})
-  install(TARGETS ${name} DESTINATION bin)
   add_test(NAME ${name} COMMAND ${name})
-endforeach( sourcefile ${tests} )
+endforeach()


### PR DESCRIPTION
Use CMake 3.3 by default to provide better support for language
standards, target properties and standard modules.

Default build type for single mode generators to RelWithDebInfo
for compilance with typical Linux packaging standards.

Use CMAKE_CXX_... variables to required C++11 rather than adding
compiler specific flag. Document that this is not as fully featured
as true compile features.

Build library with target_... to provide propagation of usage
requirements. In this case, it is only include paths.

Use GNUInstalDirs and variables to install build products in a
standard GNU/Unix style hierarchy with full relocatability.

Generate CMake package config files using all features of
package config helpers module to provide consistent variables,
imported targets and relocatability.
