### PR TITLE
Set HSF_PLATFORM to reasonable default

### DIFF
--- a/project_template/cmake/HSFTEMPLATECPack.cmake
+++ b/project_template/cmake/HSFTEMPLATECPack.cmake
@@ -26,16 +26,23 @@ if(buildtype_lower STREQUAL "release")
   set(HSF_BUILDTYPE "opt")
 elseif(buildtype_lower STREQUAL "debug")
   set(HSF_BUILDTYPE "dbg")
-elseif(buildtype_lower STREQUAL "relwithbebinfo")
+elseif(buildtype_lower STREQUAL "relwithdebinfo")
   set(HSF_BUILDTYPE "owd")
 endif()
 
 
-#--- use HSF platform name -----------------------------------------------------
+#--- use HSF platform name if possible -----------------------------------------
 execute_process(
   COMMAND hsf_get_platform.py --buildtype ${HSF_BUILDTYPE}
   OUTPUT_VARIABLE HSF_PLATFORM OUTPUT_STRIP_TRAILING_WHITESPACE)
 
+# If hsf_get_platform isn't available, use CMake standard variables in same layout
+# Don't use versions for system/compiler as these do not match HSF versioning
+# for system directly.
+if(NOT HSF_PLATFORM)
+  set(HSF_PLATFORM "${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}-${CMAKE_CXX_COMPILER_ID}-${HSF_BUILDTYPE}")
+  string(TOLOWER ${HSF_PLATFORM} HSF_PLATFORM)
+endif()
 
 set(CPACK_PACKAGE_RELOCATABLE True)
 set(CPACK_PACKAGE_INSTALL_DIRECTORY "HSFTEMPLATE_${HSFTEMPLATE_VERSION}")

--- a/project_template/cmake/HSFTEMPLATECPack.cmake
+++ b/project_template/cmake/HSFTEMPLATECPack.cmake
@@ -21,27 +21,119 @@ set(CPACK_SOURCE_IGNORE_FILES
 set(CPACK_SOURCE_STRIP_FILES "")
 
 #--- translate buildtype -------------------------------------------------------
-string( TOLOWER "${CMAKE_BUILD_TYPE}" buildtype_lower )
-if(buildtype_lower STREQUAL "release")
+if(NOT CMAKE_CONFIGURATION_TYPES)
+  string(TOLOWER "${CMAKE_BUILD_TYPE}" HSF_DEFAULT_BUILDTYPE)
+endif()
+
+set(HSF_BUILDTYPE "unknown")
+
+if(HSF_DEFAULT_BUILDTYPE STREQUAL "release")
   set(HSF_BUILDTYPE "opt")
-elseif(buildtype_lower STREQUAL "debug")
+elseif(HSF_DEFAULT_BUILDTYPE STREQUAL "debug")
   set(HSF_BUILDTYPE "dbg")
-elseif(buildtype_lower STREQUAL "relwithdebinfo")
+elseif(HSF_DEFAULT_BUILDTYPE STREQUAL "relwithdebinfo")
   set(HSF_BUILDTYPE "owd")
 endif()
 
-
 #--- use HSF platform name if possible -----------------------------------------
+function(hsf_get_platform _output_var)
+  # - Determine arch for target of project build
+  set(HSF_ARCH ${CMAKE_SYSTEM_PROCESSOR})
+
+  # - Translate compiler info to HSF format
+  string(TOLOWER ${CMAKE_C_COMPILER_ID} HSF_COMPILER_ID)
+  if(NOT HSF_COMPILER_ID)
+    set(HSF_COMPILER_ID "unknown")
+  endif()
+
+  set(HSF_COMPILER_VERSION ${CMAKE_C_COMPILER_VERSION})
+  if(NOT HSF_COMPILER_VERSION)
+    set(HSF_COMPILER_VERSION "0")
+  endif()
+  # Strip version to MAJORMINOR (?)
+  string(REGEX REPLACE "([a-z0-9]+)(\.|-|_)([a-z0-9]+).*" "\\1\\3" HSF_COMPILER_VERSION ${HSF_COMPILER_VERSION})
+
+  # - Determine OS info
+  # NOTE: This derives *HOST* OS info, *NOT* *TARGET* OS
+  #       Needs more thought for cross-compile cases, though likely reduces
+  #       to check on CMAKE_CROSS_COMPILING and subsequent use of the needed
+  #       variables as defined in the toolchain file
+  if(APPLE)
+    set(HSF_OS_ID "macos")
+    execute_process(COMMAND sw_vers -productVersion
+      COMMAND cut -d . -f 1-2
+      OUTPUT_VARIABLE HSF_OS_VERSION
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+    string(REPLACE "." "" HSF_OS_VERSION ${HSF_OS_VERSION})
+  elseif(WIN32)
+    # Should be able to determine gross Windows version from CMAKE_SYSTEM_VERSION
+    set(HSF_OS_ID "win")
+    if(CMAKE_SYSTEM_VERSION VERSION_EQUAL "6.1")
+      set(HSF_OS_VERSION "7")
+    elseif(CMAKE_SYSTEM_VERSION VERSION_EQUAL "6.2")
+      set(HSF_OS_VERSION "8")
+    elseif(CMAKE_SYSTEM_VERSION VERSION_EQUAL "6.3")
+      set(HSF_OS_VERSION "8")
+    elseif(CMAKE_SYSTEM_VERSION VERSION_EQUAL "10.0")
+      set(HSF_OS_VERSION "10")
+    else()
+      set(HSF_OS_VERSION "unknown")
+    endif()
+  elseif(CMAKE_SYSTEM_NAME MATCHES "Linux")
+    # Use /etc/os-release if it's present
+    if(EXISTS "/etc/os-release")
+      # - Parse based on spec from freedesktop
+      # http://www.freedesktop.org/software/systemd/man/os-release.html
+      # - ID
+      file(STRINGS "/etc/os-release" HSF_OS_ID REGEX "^ID=.*$")
+      string(REGEX REPLACE "ID=|\"" "" HSF_OS_ID ${HSF_OS_ID})
+      # - VERSION_ID
+      file(STRINGS "/etc/os-release" HSF_OS_VERSION REGEX "^VERSION_ID=.*$")
+      string(REGEX REPLACE "VERSION_ID=|\"" "" HSF_OS_VERSION ${HSF_OS_VERSION})
+      string(REGEX REPLACE "([a-z0-9]+)(\.|-|_)([a-z0-9]+).*" "\\1\\3" HSF_OS_VERSION ${HSF_OS_VERSION})
+    else()
+      # Workaround for older systems
+      # 1. Might be lucky and have lsb_release
+      find_program(HSFTEMPLATE_LSB_RELEASE_EXECUTABLE lsb_release
+        DOC "Path to lsb_release program"
+        )
+      mark_as_advanced(HSFTEMPLATE_LSB_RELEASE_EXECUTABLE)
+      if(HSFTEMPLATE_LSB_RELEASE_EXECUTABLE)
+        # - ID
+        execute_process(COMMAND ${HSFTEMPLATE_LSB_RELEASE_EXECUTABLE} -is
+          OUTPUT_VARIABLE HSF_OS_ID
+          OUTPUT_STRIP_TRAILING_WHITESPACE
+          )
+        string(TOLOWER ${HSF_OS_ID} HSF_OS_ID)
+        # - Version
+        execute_process(COMMAND ${HSFTEMPLATE_LSB_RELEASE_EXECUTABLE} -ir
+          OUTPUT_VARIABLE HSF_OS_VERSION
+          OUTPUT_STRIP_TRAILING_WHITESPACE
+          )
+        string(REGEX REPLACE "([a-z0-9]+)(\.|-|_)([a-z0-9]+).*" "\\1\\3" HSF_OS_VERSION ${HSF_OS_VERSION})
+      else()
+        # 2. Only mark in general terms, or have to check for possible /etc/VENDOR-release files
+        set(HSF_OS_ID "linux")
+        string(REGEX REPLACE "([a-z0-9]+)(\.|-|_)([a-z0-9]+).*" "\\1\\3" HSF_OS_VERSION ${CMAKE_SYSTEM_VERSION})
+      endif()
+    endif()
+  else()
+    set(HSF_OS_ID "unknown")
+    set(HSF_OS_VERSION "0")
+  endif()
+
+  set(${_output_var} "${HSF_ARCH}-${HSF_OS_ID}${HSF_OS_VERSION}-${HSF_COMPILER_ID}${HSF_COMPILER_VERSION}-${HSF_BUILDTYPE}" PARENT_SCOPE)
+endfunction()
+
 execute_process(
   COMMAND hsf_get_platform.py --buildtype ${HSF_BUILDTYPE}
-  OUTPUT_VARIABLE HSF_PLATFORM OUTPUT_STRIP_TRAILING_WHITESPACE)
+  OUTPUT_VARIABLE HSF_PLATFORM OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
 
-# If hsf_get_platform isn't available, use CMake standard variables in same layout
-# Don't use versions for system/compiler as these do not match HSF versioning
-# for system directly.
+# If hsf_get_platform isn't available, use CMake function
 if(NOT HSF_PLATFORM)
-  set(HSF_PLATFORM "${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}-${CMAKE_CXX_COMPILER_ID}-${HSF_BUILDTYPE}")
-  string(TOLOWER ${HSF_PLATFORM} HSF_PLATFORM)
+  hsf_get_platform(HSF_PLATFORM)
 endif()
 
 set(CPACK_PACKAGE_RELOCATABLE True)


### PR DESCRIPTION
As reported in Issue #6, template CPack file relies on HSF program
hsf_get_platform.py being present in the path. If it is not, the
platform variable HSF_PLATFORM is unset.

If HSF_PLATFORM is empty after an attempt to run hsf_get_platform.py,
set it to a value derived from CMake's knowledge of the system
processor arch, name and CXX compiler vendor ID. Do not use system
or compiler versions as these do not match the HSF conventions (e.g.
system version on Linux/Darwin is the kernel version).

Note that this assumes a CXX compiler has been configured.
