### PR TITLE
Use explicit source listing

### DIFF
--- a/project_template/package/CMakeLists.txt
+++ b/project_template/package/CMakeLists.txt
@@ -1,8 +1,14 @@
-## select all source files
-file(GLOB sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
+# List sources for target
+# - Note that we include headers. CMake will resolve dependencies on headers
+#   correctly, but they will not show up in IDEs like Xcode if they are not
+#   listed in the files for a target
+set(examplelibrary_SOURCES
+  include/HSFTEMPLATE/Example.h
+  src/Example.cpp
+  )
 
 ## create a library target
-add_library(examplelibrary SHARED ${sources})
+add_library(examplelibrary SHARED ${examplelibrary_SOURCES})
 
 # - Define its header interface when building and when installed
 # (i.e. used by a third party)
@@ -21,11 +27,13 @@ target_include_directories(examplelibrary
 # use by client projects
 install(TARGETS examplelibrary
   EXPORT HSFTEMPLATETargets
-  DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
 
 ## install the headers
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/HSFTEMPLATE
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  )
 
 ## handling of test executables
 add_subdirectory(tests)

--- a/project_template/package/tests/CMakeLists.txt
+++ b/project_template/package/tests/CMakeLists.txt
@@ -3,13 +3,19 @@
 # than used from the system!
 find_package(GTest REQUIRED)
 
-## handling of test executables
-## here a generic example for creating one executable per .cpp is shown
-file(GLOB tests RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
-message(${tests})
-foreach( sourcefile ${tests} )
-  string( REPLACE ".cpp" "" name ${sourcefile} )
-  add_executable( ${name} ${sourcefile} )
-  target_link_libraries( ${name} examplelibrary  ${GTEST_LIBRARIES})
-  add_test(NAME ${name} COMMAND ${name})
-endforeach()
+# - handling of test executables
+# Here a generic example for creating an executable then defining it as a
+# test to CTest
+# 1. Create executable
+add_executable(test_example test_example.cpp)
+
+# 2. Link it to the librayr being tested, plus the unit test library(ies)
+target_link_libraries(test_example examplelibrary ${GTEST_LIBRARIES})
+
+# 3. Add the test program as a command to be run as a test
+# Note: NAME is what will be shown in CTest, COMMAND is what will be run
+#       CMake knows that text_example is a CMake target, and knows where
+#       the resultant executable is. Things like PATH and so on do not need
+#       to be set.
+add_test(NAME testExampleClass COMMAND test_example)
+


### PR DESCRIPTION
GLOBs in CMake are only evaluated by cmake and not the buildtool
generated for. With GLOB, adding/removing files requires an explicit,
by hand rerun of cmake in order to add/remove the files from the
buildscripts. This can lead to inconsistent builds and/or cryptic
error messages especially when developing over VCS. GLOBs also make
it more complicated to handle configurable builds where sources may be
used or not depending on configure-time options.

Explicit listing overcomes these issues as the CMake scripts are a
dependency of the project. Adding/removing a file and its listing in
a CMake script result it an automatic re-run of CMake before the build
itself is rerun. Forgetting to add/remove a file listing typically
leads to faster errors, with clearer error messages.

Remove use of GLOB to list source files, following CMake recommended
practice. Projects may use GLOB in the future, but HSF should not
recommend it in the first instance.
