### PR TITLE
Simplify Doxygen config/build

### DIFF
--- a/hsf_create_project.py
+++ b/hsf_create_project.py
@@ -103,7 +103,6 @@ class ProjectCreator(object):
         os.rename(join(self.target_dir,"cmake/HSFTEMPLATECPack.cmake"),join(self.target_dir,"cmake/%sCPack.cmake" %self.name))
         os.rename(join(self.target_dir,"cmake/HSFTEMPLATEConfig.cmake.in"),join(self.target_dir,"cmake/%sConfig.cmake.in" %self.name))
         os.rename(join(self.target_dir,"cmake/HSFTEMPLATECreateConfig.cmake"),join(self.target_dir,"cmake/%sCreateConfig.cmake" %self.name))
-        os.rename(join(self.target_dir,"cmake/HSFTEMPLATEDoxygen.cmake"),join(self.target_dir,"cmake/%sDoxygen.cmake" %self.name))
         os.rename(join(self.target_dir,"HSFTEMPLATEVersion.h"),join(self.target_dir,"%sVersion.h" %self.name))
         os.rename(join(self.target_dir,"package/include/example"),join(self.target_dir,"package/include/%s" %self.name))
         os.rename(join(self.target_dir,"package"),join(self.target_dir,"%s" %self.subpackage_name))

--- a/project_template/CMakeLists.txt
+++ b/project_template/CMakeLists.txt
@@ -44,7 +44,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 #--- Declare options -----------------------------------------------------------
-option(HSFTEMPLATE_documentation "Whether or not to create doxygen doc target.")
+option(HSFTEMPLATE_BUILD_DOCS "Whether or not to create doxygen doc target.")
 
 #--- enable unit testing capabilities ------------------------------------------
 include(CTest)
@@ -53,8 +53,8 @@ include(CTest)
 include(cmake/HSFTEMPLATECPack.cmake)
 
 #--- target for Doxygen documentation ------------------------------------------
-if(HSFTEMPLATE_documentation)
-  include(cmake/HSFTEMPLATEDoxygen.cmake)
+if(HSFTEMPLATE_BUILD_DOCS)
+  add_subdirectory(doc)
 endif()
 
 #--- add version files ---------------------------------------------------------

--- a/project_template/README.md
+++ b/project_template/README.md
@@ -6,21 +6,26 @@ Please add some lines describing the project!
 
     mkdir build
     cd build
-    cmake -DCMAKE_INSTALL_PREFIX=<installdir>  <path to sources>
+    cmake -DCMAKE_INSTALL_PREFIX=<installdir> [-DHSFTEMPLATE_BUILD_DOCS=ON] <path to sources>
     make -j<number of cores on your machine>
     make install
 
-
-Pleae note that this project depends on an existing installation of gtest. It may be necessary to include its location into _CMAKE_PREFIX_PATH_. For further details please have a look at http://www.cmake.org/cmake-tutorial/ .
+The `HSFTEMPLATE_BUILD_DOCS` variable is optional, and should be passed if you wish to
+build the Doxygen based API documentation. Please note that this requires an existing
+installation of [Doxygen](http://www.doxygen.org/index.html). If CMake cannot locate
+Doxygen, its install location should be added into `CMAKE_PREFIX_PATH`. 
+For further details please have a look at [the CMake tutorial](http://www.cmake.org/cmake-tutorial/).
 
 ## Building the documentation
 
-The documentation of the project is based on doxygen. Invoking
+The documentation of the project is based on doxygen. To build the documentation,
+the project must have been configured with `HSFTEMPLATE_BUILD_DOCS` enabled, as
+described earlier. It can then be built and installed:
 
     make doc
     make install
 
-installs the documentation into installdir/doxygen.
+By default, this installs the documentation into `<installdir>/share/doc/HSFTEMPLATE/doxygen`.
 
 ## Creating a package with CPack
 
@@ -36,4 +41,4 @@ To run the tests of the project, first build it and then invoke
 
 ## Inclusion into other projects
 
-If you want to build your own project against HSFTEMPLATE, CMake may be the best option for you. Just add its location to _CMAKE_PREFIX_PATH_ and call _find_package(HSFTEMPLATE)_ within your CMakeLists.txt.
+If you want to build your own project against HSFTEMPLATE, CMake may be the best option for you. Just add its location to `CMAKE_PREFIX_PATH` and call `find_package(HSFTEMPLATE)` within your CMakeLists.txt.

--- a/project_template/doc/CMakeLists.txt
+++ b/project_template/doc/CMakeLists.txt
@@ -1,13 +1,12 @@
 find_package(Doxygen)
 if(DOXYGEN_FOUND)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doc/Doxyfile.in
-                 ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
+  configure_file(Doxyfile.in Doxyfile @ONLY)
   add_custom_target(doc
-                    ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+                    ${DOXYGEN_EXECUTABLE} Doxyfile
                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                     COMMENT "Generating API documentation with Doxygen" VERBATIM)
 
   install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doxygen
     DESTINATION ${CMAKE_INSTALL_DOCDIR}/doxygen
-    OPTIONAL)
+    )
 endif()

--- a/project_template/doc/Doxyfile.in
+++ b/project_template/doc/Doxyfile.in
@@ -32,13 +32,13 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "HSFTEMPLATE"
+PROJECT_NAME           = "@PROJECT_NAME@"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = @CMAKE_PROJECT_VERSION@
+PROJECT_NUMBER         = @PROJECT_VERSION@
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = @CMAKE_BINARY_DIR@/doxygen
+OUTPUT_DIRECTORY       = @PROJECT_BINARY_DIR@/doc/doxygen
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -144,7 +144,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = @CMAKE_SOURCE_DIR@ @CMAKE_BINARY_DIR@
+STRIP_FROM_PATH        = @PROJECT_SOURCE_DIR@ @PROJECT_BINARY_DIR@ 
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -153,7 +153,7 @@ STRIP_FROM_PATH        = @CMAKE_SOURCE_DIR@ @CMAKE_BINARY_DIR@
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    = @DOXYGEN_INCLUDE_DIRS@ @CMAKE_BINARY_DIR@/include
+STRIP_FROM_INC_PATH    = @DOXYGEN_INCLUDE_DIRS@ @PROJECT_BINARY_DIR@/include
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't
@@ -731,7 +731,7 @@ WARN_FORMAT            = "$file:$line: $text"
 # messages should be written. If left blank the output is written to standard
 # error (stderr).
 
-WARN_LOGFILE           = @CMAKE_BINARY_DIR@/doxygen-warnings.log
+WARN_LOGFILE           = @PROJECT_BINARY_DIR@/doxygen-warnings.log
 
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
@@ -743,9 +743,8 @@ WARN_LOGFILE           = @CMAKE_BINARY_DIR@/doxygen-warnings.log
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = @CMAKE_SOURCE_DIR@
-INPUT                 += @CMAKE_BINARY_DIR@/include
-INPUT                 += @CMAKE_CURRENT_BINARY_DIR@
+INPUT                  = @PROJECT_SOURCE_DIR@
+INPUT                 += @PROJECT_BINARY_DIR@/include
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -801,7 +800,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       =  */tests/* */dict/* */cmake/* @CMAKE_BINARY_DIR@
+EXCLUDE_PATTERNS       =  */tests/* */dict/* */cmake/* @PROJECT_BINARY_DIR@
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the
@@ -818,7 +817,7 @@ EXCLUDE_SYMBOLS        =
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           = @CMAKE_SOURCE_DIR@
+EXAMPLE_PATH           = @PROJECT_SOURCE_DIR@
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and
@@ -886,7 +885,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = README.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing
@@ -1096,7 +1095,7 @@ HTML_EXTRA_FILES       = @DOXYGEN_HTML_EXTRA_FILES@
 # Minimum value: 0, maximum value: 359, default value: 220.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_COLORSTYLE_HUE    = 0
+HTML_COLORSTYLE_HUE    = 220
 
 # The HTML_COLORSTYLE_SAT tag controls the purity (or saturation) of the colors
 # in the HTML output. For a value of 0 the output will use grayscales only. A


### PR DESCRIPTION
This is a slightly more speculative PR as some of it is style and I'm not an expert on Doxygen config. At least, I think it's tricky to make the latter completely generic...

The PR is in two commits (ignore the Merge branch commits, those should be in master already, so I don't know why Github's included them) and covers
1. Moving the Doxygen CMake module to where it's actually used. This makes the purpose and use a bit clearer for users, plus it permits slightly shorter relative paths to be used. The switch to activate Doxygen is also renamed to use the same style as the `BUILD_TESTS` option. I think that is a bit clearer, and puts everything in the same order when working through the curses/GUI. It _could_ be renamed `BUILD_DOCS` rather than `BUILD_DOXYGEN`.
2. Consistent use of CMake expansion variables in the Doxyfile.in, and using `PROJECT_` rather than `CMAKE_` scope. Some stripping of inc/paths has been added, but I'm less sure about this given the use of currently unused/undocumented `DOXYGEN_` expansion variables. If these are to be used, let me know, and I'll update these as needed (A google suggests these originate in the Gaudi build scripts?) 
3. Move the versioning header into the same location as other project headers. This allows it to be easily added to the library target, so it appears in IDEs (tested on Xcode) and provides an example of integrating/installing a generated source. It also makes the header appear in a more logical location in the documentation. This is in this PR as it otherwise broke the documentation build.
