### PR TITLE
Create/use uninstall target

### DIFF
--- a/hsf_create_project.py
+++ b/hsf_create_project.py
@@ -104,6 +104,8 @@ class ProjectCreator(object):
         os.rename(join(self.target_dir,"cmake/HSFTEMPLATEConfig.cmake.in"),join(self.target_dir,"cmake/%sConfig.cmake.in" %self.name))
         os.rename(join(self.target_dir,"cmake/HSFTEMPLATECreateConfig.cmake"),join(self.target_dir,"cmake/%sCreateConfig.cmake" %self.name))
         os.rename(join(self.target_dir,"cmake/HSFTEMPLATEDoxygen.cmake"),join(self.target_dir,"cmake/%sDoxygen.cmake" %self.name))
+        os.rename(join(self.target_dir,"cmake/HSFTEMPLATEUninstall.cmake"),join(self.target_dir,"cmake/%sUninstall.cmake" %self.name))
+        os.rename(join(self.target_dir,"cmake/HSFTEMPLATE_uninstall.cmake.in"),join(self.target_dir,"cmake/%s_uninstall.cmake.in" %self.name))
         os.rename(join(self.target_dir,"HSFTEMPLATEVersion.h"),join(self.target_dir,"%sVersion.h" %self.name))
         os.rename(join(self.target_dir,"package/include/example"),join(self.target_dir,"package/include/%s" %self.name))
         os.rename(join(self.target_dir,"package"),join(self.target_dir,"%s" %self.subpackage_name))

--- a/project_template/CMakeLists.txt
+++ b/project_template/CMakeLists.txt
@@ -73,3 +73,6 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE
 
 #--- project specific subdirectories -------------------------------------------
 add_subdirectory(HSFSUBPACKAGE)
+
+#--- create uninstall target ---------------------------------------------------
+include(cmake/HSFTEMPLATEUninstall.cmake)

--- a/project_template/cmake/HSFTEMPLATEUninstall.cmake
+++ b/project_template/cmake/HSFTEMPLATEUninstall.cmake
@@ -1,0 +1,46 @@
+#.rst:
+# HSFTEMPLATEUninstallTarget
+# ---------------------------
+# Add an `uninstall` target
+#
+
+#=============================================================================
+# Copyright 2015 Alex Merry <alex.merry@kde.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. The name of the author may not be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+if (NOT TARGET uninstall)
+    configure_file(
+      "${CMAKE_CURRENT_LIST_DIR}/HSFTEMPLATE_uninstall.cmake.in"
+      "${CMAKE_BINARY_DIR}/HSFTEMPLATE_uninstall.cmake"
+        IMMEDIATE
+        @ONLY
+    )
+
+    add_custom_target(uninstall
+      COMMAND "${CMAKE_COMMAND}" -P "${CMAKE_BINARY_DIR}/HSFTEMPLATE_uninstall.cmake"
+      WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+    )
+endif()
+

--- a/project_template/cmake/HSFTEMPLATE_uninstall.cmake.in
+++ b/project_template/cmake/HSFTEMPLATE_uninstall.cmake.in
@@ -1,0 +1,21 @@
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+    message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+    message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+    if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+        exec_program(
+            "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+            OUTPUT_VARIABLE rm_out
+            RETURN_VALUE rm_retval
+            )
+        if(NOT "${rm_retval}" STREQUAL 0)
+            message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+        endif()
+    else()
+        message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+    endif()
+endforeach()


### PR DESCRIPTION
By default, CMake does not provide an `uninstall` target. Use KDE
example implementation for the template project to provide this
useful target out the box.

Users can then run `make uninstall` (for example, but target is available for all generators) 
