### PR TITLE
Configure/install pkg-config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Software Foundation (HSF).
 ## hsf_create_project
 The tool hsf_create_project creates a template CMake project. The created project
 contains the standard use patterns for small CMake projects, plus support for
-Doxygen, CPack, and gtest. Further documentation is provided within the created
+Doxygen and CPack. Further documentation is provided within the created
 package itself inside the README.md.
 
 ## hsf_get_platform and hsf_platform_compatibility

--- a/hsf_create_project.py
+++ b/hsf_create_project.py
@@ -105,6 +105,7 @@ class ProjectCreator(object):
         os.rename(join(self.target_dir,"cmake/HSFTEMPLATECreateConfig.cmake"),join(self.target_dir,"cmake/%sCreateConfig.cmake" %self.name))
         os.rename(join(self.target_dir,"cmake/HSFTEMPLATEUninstall.cmake"),join(self.target_dir,"cmake/%sUninstall.cmake" %self.name))
         os.rename(join(self.target_dir,"cmake/HSFTEMPLATE_uninstall.cmake.in"),join(self.target_dir,"cmake/%s_uninstall.cmake.in" %self.name))
+        os.rename(join(self.target_dir,"cmake/HSFTEMPLATE.pc.in"),join(self.target_dir,"cmake/%s.pc.in" %self.name))
         os.rename(join(self.target_dir,"HSFTEMPLATEVersion.h"),join(self.target_dir,"%sVersion.h" %self.name))
         os.rename(join(self.target_dir,"package/include/example"),join(self.target_dir,"package/include/%s" %self.name))
         os.rename(join(self.target_dir,"package"),join(self.target_dir,"%s" %self.subpackage_name))

--- a/project_template/README.md
+++ b/project_template/README.md
@@ -13,7 +13,7 @@ Please add some lines describing the project!
 The `HSFTEMPLATE_BUILD_DOCS` variable is optional, and should be passed if you wish to
 build the Doxygen based API documentation. Please note that this requires an existing
 installation of [Doxygen](http://www.doxygen.org/index.html). If CMake cannot locate
-Doxygen, its install location should be added into `CMAKE_PREFIX_PATH`. 
+Doxygen, its install location should be added into `CMAKE_PREFIX_PATH`.
 For further details please have a look at [the CMake tutorial](http://www.cmake.org/cmake-tutorial/).
 
 ## Building the documentation
@@ -42,3 +42,7 @@ To run the tests of the project, first build it and then invoke
 ## Inclusion into other projects
 
 If you want to build your own project against HSFTEMPLATE, CMake may be the best option for you. Just add its location to `CMAKE_PREFIX_PATH` and call `find_package(HSFTEMPLATE)` within your CMakeLists.txt.
+
+A `pkg-config` `.pc` file is also installed if you do not use CMake.
+Simply add the location of the `.pc` file (nominally `<installdir>/lib/pkgconfig`) and run `pkg-config --cflags --libs HSFTEMPLATE` to get the
+include paths and libraries needed to compile and link to HSFTEMPLATE.

--- a/project_template/cmake/HSFTEMPLATE.pc.in
+++ b/project_template/cmake/HSFTEMPLATE.pc.in
@@ -1,0 +1,9 @@
+prefix=${pcfiledir}/@HSFTEMPLATE_PCFILEDIR_TO_PREFIX@
+libdir=${prefix}@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: @PROJECT_NAME@
+Version: @PROJECT_VERSION@
+Description: "Description of @PROJECT_NAME@" 
+Libs: -L${libdir} -lexamplelibrary
+Cflags: -I${includedir}

--- a/project_template/cmake/HSFTEMPLATECreateConfig.cmake
+++ b/project_template/cmake/HSFTEMPLATECreateConfig.cmake
@@ -1,3 +1,4 @@
+#--- CMake Config Files -----------------------------------------------
 # - Use CMake's module to help generating relocatable config files
 include(CMakePackageConfigHelpers)
 
@@ -28,3 +29,17 @@ install(EXPORT HSFTEMPLATETargets
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/HSFTEMPLATE"
   )
 
+#--- Pkg-Config File --------------------------------------------------
+# - Derive relative pcfile -> prefix path to make pkg-config file
+#   relocatable
+file(RELATIVE_PATH HSFTEMPLATE_PCFILEDIR_TO_PREFIX
+  "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig"
+  "${CMAKE_INSTALL_PREFIX}"
+  )
+configure_file("${CMAKE_CURRENT_LIST_DIR}/HSFTEMPLATE.pc.in"
+  "${PROJECT_BINARY_DIR}/HSFTEMPLATE.pc"
+  @ONLY
+  )
+install(FILES "${PROJECT_BINARY_DIR}/HSFTEMPLATE.pc"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+  )


### PR DESCRIPTION
This provides the basic infrastructure for configuring/installing a pig-config support file.

On documentation issue is that the template pc file will need editing by project authors after generation to add the appropriate `-ltheirlibname` flags. This isn't added yet as I'm not sure where this should go.
